### PR TITLE
Updates, preparing for Mirror Conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,17 @@ To reset the game to its initial state, stop the engine, delete the `game-state.
 **Note:** If the engine is stopped and restarted, the previous game state is always loaded from disk. However, previous events won't be re-emitted. If you restart the engine *and* reopen the screens, it will look like the game just started from scratch (it will update on the next state change). So, if you restart the engine on-stage, **keep the browser windows open** and the audience won't notice a thing.
 
 _-- The Quizmaster_
+
+## Notes for Linux users
+
+If you have issues getting the controllers to work, the most likely issue is
+lack of permissions to access the HID device. The easiest fix is:
+
+1. Use the `evtest` (needs to be run with `sudo`), and test the controllers to
+   make sure the events are reaching your system. If they're not, the rest of
+   these steps won't help you
+2. Run the whole app with root access as well `sudo lein run`. (This is the lazy
+   approach, I know. I don't know, and don't care, enough about HID to find
+   a proper fix)
+
+_-- @naps62, aka the Mirror Conf Quizmaster_

--- a/src/pixelsquiz/buzz.clj
+++ b/src/pixelsquiz/buzz.clj
@@ -17,18 +17,19 @@
   (let [bits (System/getProperty "sun.arch.data.model")]
     (clojure.lang.RT/loadLibrary (str "hidapi-jni-" bits))))
 
-
 (defn open-buzz []
+  (logger/info "Trying to open Buzz controllers")
   (let [_ (load-hid-natives)
-        manager (HIDManager/getInstance)]
-    (try
-      (let [buzz (.openById manager 0x054c 0x0002 "")]
-        (logger/info "Buzz controllers detected: 054c:0002") buzz)
-    (catch Exception e
-      (try
-        (let [buzz (.openById manager 0x054c 0x1000 "")]
-          (logger/info "Buzz controllers detected: 054c:1000") buzz)
-      (catch Exception e nil)))
+        manager (HIDManager/getInstance)
+        all_devs (.listDevices manager)
+        filter_pred (fn [dev] (= (.getProduct_string dev) "Buzz"))
+        buzz_dev (first (filter filter_pred all_devs))]
+    (println buzz_dev)
+    (if (nil? buzz_dev)
+      (logger/info "Could not connect Buzz controllers")
+
+      (let [buzz (.openByPath manager (.getPath buzz_dev))]
+        (logger/info "Buzz controllers detected") buzz)
     )
   )
 )

--- a/tooling/csv-to-questions.py
+++ b/tooling/csv-to-questions.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 
 
@@ -43,11 +43,12 @@ def main():
 
         for question in questions:
             question_text = question[0].decode("utf-8").replace("\"", "&quot;")  # ...HTML is allowed here.
+            question_score = 0 if question_text.startswith("Test:") else 1
             question_options = "\" \"".join([q.decode("utf-8").replace("\"", "'") for q in question[1:5]])
             question_trivia = question[5].decode("utf-8").replace("\"", "&quot;") if len(question) > 5 else ""
 
-            out = ("  #pixelsquiz.types.Question{:id %d, :kind :multi, :score 1, :text \"%s\", :options [\"%s\"], :trivia \"%s\"}\n" %
-                   (question_id, question_text, question_options, question_trivia))
+            out = ("  #pixelsquiz.types.Question{:id %d, :kind :multi, :score %d, :text \"%s\", :options [\"%s\"], :trivia \"%s\"}\n" %
+                   (question_id, question_score, question_text, question_options, question_trivia))
 
             f.write(out.encode("utf-8"))
 


### PR DESCRIPTION
A couple of changes I made today, in preparation for [Mirror Conf](https://mirrorconf.com/).
Possibly more to come in the future

Changes in this PR:
- Questions starting with `Test:` are automatically given a score of `0`
- The Buzz controller is now connected by looping through all found HID devices, and connecting to the one named "Buzz" (using Arch Linux here, the original vendorId:productId pair was matching the existing code, but I was getting a NullPointerException when connecting. Couldn't really figure out why)
- Updates the Readme with linux-specific instructions for getting the controllers to work